### PR TITLE
🔀 :: (#61) redis 관련 query creation 오류 해결

### DIFF
--- a/src/main/java/io/github/opgg/music_ward_server/entity/token/Token.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/token/Token.java
@@ -2,11 +2,13 @@ package io.github.opgg.music_ward_server.entity.token;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @RedisHash
 public class Token {
@@ -14,18 +16,20 @@ public class Token {
     @Id
     private final Long id;
 
-    private final Type type;
+    private String musicWardRefreshToken;
 
-    private String refreshToken;
+    private String googleRefreshToken;
+
+    private String spotifyRefreshToken;
 
     @TimeToLive
     private Long ttl;
 
-    public Token update(String refreshToken, Long ttl) {
-        this.refreshToken = refreshToken;
+    public Token update(String musicWardRefreshToken, String googleRefreshToken, String spotifyRefreshToken, Long ttl) {
+        this.musicWardRefreshToken = musicWardRefreshToken;
+        this.googleRefreshToken = googleRefreshToken;
+        this.spotifyRefreshToken = spotifyRefreshToken;
         this.ttl = ttl;
         return this;
     }
-
-
 }

--- a/src/main/java/io/github/opgg/music_ward_server/entity/token/TokenRepository.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/token/TokenRepository.java
@@ -7,5 +7,4 @@ import java.util.Optional;
 
 @Repository
 public interface TokenRepository extends CrudRepository<Token, Long> {
-    Optional<Token> findByIdAndType(Long id, Type type);
 }


### PR DESCRIPTION
token 조회에 계속 실패해서 원인을 못찾아 user id 별로 모든 refresh token 데이터를 가질 수 있도록 개선하였습니다. 기존 로직에서 한 가지 의문점을 가진 것은 user는 3가지 type의 Token 데이터를 가질 수 있는데 @Id로 user id를 설정하게 되면 계속해서 중복되어 값이 저장되는 것이 아닌지에 대한 점 이었습니다. 

우선 playlist 조회 기능 진행을 위하여 최대한 기존 코드를 방해하지 않는 선에서 진행하였습니다. 추후 논의를 통해 수정해도 좋을 것 같습니다! 