### PR TITLE
🔀 :: (#75) validation 예외 handle 및 error response 수정

### DIFF
--- a/src/main/java/io/github/opgg/music_ward_server/error/ErrorResponse.java
+++ b/src/main/java/io/github/opgg/music_ward_server/error/ErrorResponse.java
@@ -1,14 +1,23 @@
 package io.github.opgg.music_ward_server.error;
 
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.github.opgg.music_ward_server.error.exception.ErrorCode;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ErrorResponse {
 
     private final int status;
     private final String message;
+    private List<Error> errors;
 
     @Override
     public String toString() {
@@ -16,5 +25,41 @@ public class ErrorResponse {
                 "\t\"status\": " + status +
                 ",\n\t\"message\": \"" + message + '\"' +
                 "\n}";
+    }
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public ErrorResponse(ErrorCode code, BindingResult bindingResult) {
+        this.status = code.getStatus();
+        this.message = code.getMessage();
+        this.errors = Error.of(bindingResult);
+    }
+
+    @Getter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Error {
+        private String field;
+        private String value;
+        private String reason;
+
+        private Error(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        private static List<Error> of(BindingResult bindingResult) {
+            List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new Error(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/io/github/opgg/music_ward_server/error/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/opgg/music_ward_server/error/GlobalExceptionHandler.java
@@ -4,11 +4,19 @@ import io.github.opgg.music_ward_server.error.exception.ErrorCode;
 import io.github.opgg.music_ward_server.error.exception.MusicWardException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(BindException e) {
+        ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
 
     @ExceptionHandler(MusicWardException.class)
     public ResponseEntity<ErrorResponse> serverExceptionHandler(MusicWardException e) {

--- a/src/main/java/io/github/opgg/music_ward_server/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/opgg/music_ward_server/error/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(404, "User not found."),
     CHAMPION_NOT_FOUND(404, "Champion not found."),
     CREDENTIALS_NOT_FOUND(401, "Credentials not found."),
-    EMPTY_REFRESH_TOKEN(401, "Empty refresh token");
+    EMPTY_REFRESH_TOKEN(401, "Empty refresh token."),
+    INVALID_INPUT_VALUE(400, "Invalid input value.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59357153/130348204-f1ed8450-f9cc-47a2-8234-89a4b5ca8a4a.png)

위와 같이 validation을 활용한 예외는 list로 에러 메시지가 보여질 수 있도록 ErrorResponse를 수정하였습니다. errors가 `isEmpty == true`인 경우 `@JsonInclude(JsonInclude.Include.NON_EMPTY)`로 인하여 생략되는 것을 보장합니다.