### PR TITLE
🔀 :: (#155) 챔피언 별 랭킹 목록 조회 구현

### DIFF
--- a/src/main/java/io/github/opgg/music_ward_server/controller/RankingController.java
+++ b/src/main/java/io/github/opgg/music_ward_server/controller/RankingController.java
@@ -1,0 +1,2 @@
+package io.github.opgg.music_ward_server.controller;public class RankingController {
+}

--- a/src/main/java/io/github/opgg/music_ward_server/controller/RankingController.java
+++ b/src/main/java/io/github/opgg/music_ward_server/controller/RankingController.java
@@ -1,2 +1,29 @@
-package io.github.opgg.music_ward_server.controller;public class RankingController {
+package io.github.opgg.music_ward_server.controller;
+
+import io.github.opgg.music_ward_server.controller.response.CommonResponse;
+import io.github.opgg.music_ward_server.service.champion.ChampionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/")
+@RequiredArgsConstructor
+@RestController
+public class RankingController {
+
+    private final ChampionService championService;
+
+    @GetMapping("ranking/{rankingType}")
+    public ResponseEntity<CommonResponse> getRanking(@PathVariable("rankingType") String rankingType) {
+
+        if (rankingType.equals("champion")) {
+            return new ResponseEntity<>(new CommonResponse(championService.getRanking()), HttpStatus.OK);
+        }
+
+        return new ResponseEntity<>(new CommonResponse(null), HttpStatus.OK);
+    }
 }

--- a/src/main/java/io/github/opgg/music_ward_server/dto/champion/response/ChampionRankingResponse.java
+++ b/src/main/java/io/github/opgg/music_ward_server/dto/champion/response/ChampionRankingResponse.java
@@ -1,0 +1,2 @@
+package io.github.opgg.music_ward_server.dto.champion.response;public class ChampionRankingResponse {
+}

--- a/src/main/java/io/github/opgg/music_ward_server/dto/champion/response/ChampionRankingResponse.java
+++ b/src/main/java/io/github/opgg/music_ward_server/dto/champion/response/ChampionRankingResponse.java
@@ -1,2 +1,23 @@
-package io.github.opgg.music_ward_server.dto.champion.response;public class ChampionRankingResponse {
+package io.github.opgg.music_ward_server.dto.champion.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.github.opgg.music_ward_server.entity.champion.Champion;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ChampionRankingResponse {
+
+    private ChampionMainResponse champion;
+    private int view;
+    private int wardsTotal;
+    private int commentsTotal;
+
+    public ChampionRankingResponse(Champion champion, int view, int wardsTotal, int commentsTotal) {
+        this.champion = new ChampionMainResponse(champion);
+        this.view = view;
+        this.wardsTotal = wardsTotal;
+        this.commentsTotal = commentsTotal;
+    }
 }

--- a/src/main/java/io/github/opgg/music_ward_server/entity/champion/Champion.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/champion/Champion.java
@@ -2,6 +2,7 @@ package io.github.opgg.music_ward_server.entity.champion;
 
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionListDTO;
 import io.github.opgg.music_ward_server.entity.BaseEntity;
+import io.github.opgg.music_ward_server.entity.playlist.Playlist;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +13,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 @Getter
@@ -40,6 +41,9 @@ public class Champion extends BaseEntity {
     private String profileImageUrl;
 
     private String imageUrl;
+
+    @OneToMany(mappedBy = "champion")
+    private List<Playlist> playlists = new ArrayList<>();
 
     @Builder
     public Champion(String name, String englishName, String story,

--- a/src/main/java/io/github/opgg/music_ward_server/entity/champion/ChampionRepository.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/champion/ChampionRepository.java
@@ -1,11 +1,19 @@
 package io.github.opgg.music_ward_server.entity.champion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChampionRepository extends JpaRepository<Champion, Long> {
+
     Optional<Champion> findByName(String name);
+
+    @Query("select distinct c " +
+            "from tbl_champion c " +
+            "join fetch c.playlists")
+    List<Champion> findAll();
 }

--- a/src/main/java/io/github/opgg/music_ward_server/entity/comment/Comment.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/comment/Comment.java
@@ -41,6 +41,7 @@ public class Comment extends BaseEntity {
         this.content = content;
         this.user = user;
         this.playlist = playlist;
+        this.playlist.getComments().add(this);
     }
 
     public void changeUser(User user) {

--- a/src/main/java/io/github/opgg/music_ward_server/entity/playlist/Playlist.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/playlist/Playlist.java
@@ -2,7 +2,9 @@ package io.github.opgg.music_ward_server.entity.playlist;
 
 import io.github.opgg.music_ward_server.entity.BaseEntity;
 import io.github.opgg.music_ward_server.entity.champion.Champion;
+import io.github.opgg.music_ward_server.entity.comment.Comment;
 import io.github.opgg.music_ward_server.entity.user.User;
+import io.github.opgg.music_ward_server.entity.ward.Ward;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +21,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -58,6 +63,12 @@ public class Playlist extends BaseEntity {
     @JoinColumn(name = "champion_id")
     private Champion champion;
 
+    @OneToMany(mappedBy = "playlist")
+    List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "playlist")
+    List<Ward> wards = new ArrayList<>();
+
     @Builder
     public Playlist(String originalId, Provider provider, String title, String description,
                     Image image, String externalUrl, User user, Champion champion) {
@@ -70,6 +81,7 @@ public class Playlist extends BaseEntity {
         this.view = 0;
         this.user = user;
         this.champion = champion;
+        this.champion.getPlaylists().add(this);
     }
 
     public void addView() {

--- a/src/main/java/io/github/opgg/music_ward_server/security/SecurityConfig.java
+++ b/src/main/java/io/github/opgg/music_ward_server/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET,"/champion/{championId}").permitAll()
                 .antMatchers(HttpMethod.GET,"/playlists/**").permitAll()
                 .antMatchers(HttpMethod.GET,"/users/**/playlists").permitAll()
+                .antMatchers(HttpMethod.GET,"/ranking/**").permitAll()
                 .anyRequest().authenticated()
                 .and().apply(new FilterConfigure(jwtTokenProvider, exceptionHandlerFilter));
     }

--- a/src/main/java/io/github/opgg/music_ward_server/service/champion/ChampionService.java
+++ b/src/main/java/io/github/opgg/music_ward_server/service/champion/ChampionService.java
@@ -2,8 +2,12 @@ package io.github.opgg.music_ward_server.service.champion;
 
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionDetailDTO;
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionListResponse;
+import io.github.opgg.music_ward_server.dto.champion.response.ChampionRankingResponse;
+
+import java.util.List;
 
 public interface ChampionService {
     ChampionListResponse getChampionList();
     ChampionDetailDTO getChampionDetail(Long championId);
+    List<ChampionRankingResponse> getRanking();
 }

--- a/src/main/java/io/github/opgg/music_ward_server/service/champion/ChampionServiceImpl.java
+++ b/src/main/java/io/github/opgg/music_ward_server/service/champion/ChampionServiceImpl.java
@@ -3,11 +3,14 @@ package io.github.opgg.music_ward_server.service.champion;
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionDetailDTO;
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionListDTO;
 import io.github.opgg.music_ward_server.dto.champion.response.ChampionListResponse;
+import io.github.opgg.music_ward_server.dto.champion.response.ChampionRankingResponse;
 import io.github.opgg.music_ward_server.entity.champion.Champion;
 import io.github.opgg.music_ward_server.entity.champion.ChampionRepository;
+import io.github.opgg.music_ward_server.entity.playlist.Playlist;
 import io.github.opgg.music_ward_server.exception.ChampionNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,4 +38,37 @@ public class ChampionServiceImpl implements ChampionService {
 
     }
 
+    @Override
+    public List<ChampionRankingResponse> getRanking() {
+
+        return championRepository.findAll()
+                .stream()
+                .map(champion -> {
+                    List<Playlist> playlists = champion.getPlaylists();
+
+                    int view = 0;
+                    int wardsTotal = 0;
+                    int commentsTotal = 0;
+                    for (Playlist playlist : playlists) {
+                        view += playlist.getView();
+                        wardsTotal += playlist.getWards().size();
+                        commentsTotal += playlist.getComments().size();
+                    }
+
+                    return new ChampionRankingResponse(champion, view, wardsTotal, commentsTotal);
+                })
+                .sorted(((o1, o2) -> {
+
+                    int total1 = o1.getView() + o1.getWardsTotal() + o1.getCommentsTotal();
+                    int total2 = o2.getView() + o2.getWardsTotal() + o2.getCommentsTotal();
+
+                    if (total1 < total2) {
+                        return 1;
+                    }
+
+                    return -1;
+                }))
+                .limit(10)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
챔피언 이름 별 랭킹 조회 기능을 추가하였습니다! 랭킹 순위의 기준은 우선 조회수 + 댓글 수 + 와드 수를 합산하여 랭킹을 계산하였습니다.

랭킹 조회의 경우 많은 계산이 요구 되지만 자구 조회되는 특성 때문에 중간에 cache를 하기 위한 수단이 필요하다고 생각되었습니다. 고민인 점은 redis에 이러한 데이터를 저장하고 해당 데이터를 먼저 조회하고, cache가 만료되면 랭킹를 계산하여 다시 조회할 수 있는지 궁금합니다. 관련해서 어떻게 처리하면 좋을 지 논의해보면 좋을 것 같습니다.