### PR TITLE
🔀 :: (#202) search 조회 부분 수정

### DIFF
--- a/src/main/java/io/github/opgg/music_ward_server/entity/playlist/Playlist.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/playlist/Playlist.java
@@ -3,6 +3,8 @@ package io.github.opgg.music_ward_server.entity.playlist;
 import io.github.opgg.music_ward_server.entity.BaseEntity;
 import io.github.opgg.music_ward_server.entity.champion.Champion;
 import io.github.opgg.music_ward_server.entity.comment.Comment;
+import io.github.opgg.music_ward_server.entity.tag.Tag;
+import io.github.opgg.music_ward_server.entity.track.Track;
 import io.github.opgg.music_ward_server.entity.user.User;
 import io.github.opgg.music_ward_server.entity.ward.Ward;
 import lombok.AccessLevel;
@@ -62,6 +64,9 @@ public class Playlist extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "champion_id")
     private Champion champion;
+
+    @OneToMany(mappedBy = "playlist")
+    List<Tag> tags = new ArrayList<>();
 
     @OneToMany(mappedBy = "playlist")
     List<Comment> comments = new ArrayList<>();

--- a/src/main/java/io/github/opgg/music_ward_server/entity/playlist/PlaylistRepository.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/playlist/PlaylistRepository.java
@@ -2,6 +2,7 @@ package io.github.opgg.music_ward_server.entity.playlist;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,17 +23,25 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
             "order by p.createdDate DESC ")
     List<Playlist> findAllOrderByCreatedDate();
 
+    @EntityGraph(attributePaths = {"champion"})
     @Query("select p " +
             "from tbl_playlist p " +
             "join p.champion c " +
             "where c.name like %:championName% or c.englishName like %:englishName% ")
     Page<Playlist> findByChampionName(@Param("championName") String championName,
-                                                @Param("englishName") String englishName,
-                                                Pageable pageable);
+                                      @Param("englishName") String englishName, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"champion"})
     @Query("select p " +
             "from tbl_playlist p " +
             "join p.champion c " +
             "where p.title like %:title% ")
     Page<Playlist> findByTitleContaining(@Param("title") String title, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"champion"})
+    @Query("select distinct p " +
+            "from tbl_playlist p " +
+            "join p.tags t " +
+            "where t.title like %:title% ")
+    Page<Playlist> findByTagTitle(@Param("title") String title, Pageable pageable);
 }

--- a/src/main/java/io/github/opgg/music_ward_server/entity/tag/Tag.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/tag/Tag.java
@@ -35,5 +35,6 @@ public class Tag extends BaseEntity {
     public Tag(String title, Playlist playlist) {
         this.title = title;
         this.playlist = playlist;
+        this.playlist.getTags().add(this);
     }
 }

--- a/src/main/java/io/github/opgg/music_ward_server/entity/tag/TagRepository.java
+++ b/src/main/java/io/github/opgg/music_ward_server/entity/tag/TagRepository.java
@@ -1,10 +1,6 @@
 package io.github.opgg.music_ward_server.entity.tag;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,10 +10,4 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findByPlaylistId(Long playlistId);
     void deleteByPlaylistId(Long playlistId);
-
-    @Query("select t " +
-            "from tbl_tag t " +
-            "join t.playlist p " +
-            "where t.title like %:title% ")
-    Page<Tag> findByTitle(@Param("title") String title, Pageable pageable);
 }

--- a/src/main/java/io/github/opgg/music_ward_server/service/search/SearchServiceImpl.java
+++ b/src/main/java/io/github/opgg/music_ward_server/service/search/SearchServiceImpl.java
@@ -5,7 +5,6 @@ import io.github.opgg.music_ward_server.dto.search.response.SearchSummonerRespon
 import io.github.opgg.music_ward_server.entity.comment.CommentRepository;
 import io.github.opgg.music_ward_server.entity.playlist.Playlist;
 import io.github.opgg.music_ward_server.entity.playlist.PlaylistRepository;
-import io.github.opgg.music_ward_server.entity.tag.Tag;
 import io.github.opgg.music_ward_server.entity.tag.TagRepository;
 import io.github.opgg.music_ward_server.entity.track.TrackRepository;
 import io.github.opgg.music_ward_server.entity.ward.WardRepository;
@@ -69,8 +68,7 @@ public class SearchServiceImpl implements SearchService {
     @Override
     public Page<PlaylistMainResponse> findByTagTitle(String title, Pageable pageable) {
 
-        Page<Tag> tags = tagRepository.findByTitle(title, pageable);
-        Page<Playlist> playlists = tags.map(tag -> tag.getPlaylist());
+        Page<Playlist> playlists = playlistRepository.findByTagTitle(title, pageable);
         return toPlaylistMainResponses(playlists);
     }
 
@@ -147,14 +145,14 @@ public class SearchServiceImpl implements SearchService {
     private Page<PlaylistMainResponse> toPlaylistMainResponses(Page<Playlist> playlists) {
 
         return playlists.map(playlist -> {
-            List<Tag> findTags = tagRepository.findByPlaylistId(playlist.getId());
-            List<String> tags = findTags.stream()
+            List<String> tags = tagRepository.findByPlaylistId(playlist.getId())
+                    .stream()
                     .map(tag -> tag.getTitle())
                     .collect(Collectors.toList());
 
-            Integer wardTotal = wardRepository.countByPlaylistId(playlist.getId());
-            Integer commentTotal = commentRepository.countByPlaylistId(playlist.getId());
-            Integer trackTotal = trackRepository.countByPlaylistId(playlist.getId());
+            int wardTotal = wardRepository.countByPlaylistId(playlist.getId());
+            int commentTotal = commentRepository.countByPlaylistId(playlist.getId());
+            int trackTotal = trackRepository.countByPlaylistId(playlist.getId());
 
             return new PlaylistMainResponse(playlist, tags, wardTotal, commentTotal, trackTotal);
         });


### PR DESCRIPTION
매 검색 시 조회 쿼리의 개수가 30 ~ 23회로 요청 때 마다 차이가 났지만 쿼리의 개수를 줄이고 일정하게 22회로 나올 수 있도록 수정하였습니다.

page 조회를 위한 2회
각 플레이리스 별 필요 정보 조회 4 x 5 = 20회
